### PR TITLE
Add auto link feature and get_container_name.

### DIFF
--- a/bin/cmd/cleanup_pre.sh
+++ b/bin/cmd/cleanup_pre.sh
@@ -17,17 +17,16 @@ fi
 
 case "$type" in
 	"all")
-		athena.plugins.selenium.stop_all_hubs
-		athena.plugins.selenium.stop_all_browsers
+		athena.plugins.selenium.stop_components
 		types+=(hub firefox firefox-debug chrome chrome-debug phantomjs)
 	;;
 	"hub")
-		athena.plugins.selenium.stop_all_hubs
+		athena.plugins.selenium.stop_components "hub"
 		types+=(hub)
 	;;
 	"firefox"|"firefox-debug"|"chrome"|"chrome-debug"|"phantomjs")
 		types+=("$type")
-		athena.plugins.selenium.stop_all_browsers "$type"
+		athena.plugins.selenium.stop_components "$type"
 	;;
 	*)
 		athena.fatal "Unrecognized component ${type}."

--- a/bin/cmd/start_pre.sh
+++ b/bin/cmd/start_pre.sh
@@ -3,6 +3,10 @@ CMD_DESCRIPTION="Starts the component(s)."
 athena.usage 2 "<type> <version> [--port=<port>|--instances=<nr_of_instances>] [<docker_options>...]" "$(cat <<EOF
     <type>                          ; Type of component (hub, firefox, firefox-debug, chrome, chrome-debug and phantomjs).
     <version>                       ; Version of the component. Check the documentation on how to get a list of available versions.
+	[--skip-hub]                    ; Dont link automatically with local selenium hub container.
+	[--skip-proxy]                  ; Dont link automatically with local proxy container.
+	[--link-hub=<container_name>]   ; Link with the nodes with selenium hub <container_name>. (link name: hub)
+	[--link-proxy=<container_name>] ; Link with the nodes with proxy <container_name>. (link name: athena-proxy)
     [--port=<port>]                 ; Specifies which port to be exposed on the host machine.
     [--instances=<nr_of_instances>] ; Start <nr_of_instances> intances in parallel.
 EOF
@@ -15,45 +19,77 @@ version="$(athena.arg 2)"
 # clearing arguments from the stack
 athena.pop_args 2
 
-instances=1
-instance_name="default"
-declare -a docker_options=()
 if athena.argument.argument_exists "--port" && athena.argument.argument_exists "--instances"; then
-	athena.fatal "you cannot select --port and --instances at the same time!"
+	athena.fatal "You cannot select --port and --instances at the same time..."
 fi
 
+docker_options=()
+instance_id=
 if athena.argument.argument_exists "--port"; then
 	athena.argument.get_argument_and_remove "--port" "port"
 	docker_options=("-p" "$port:4444")
-	instance_name=$port
+	instance_id=$port
 fi
 
-# if instances are specified then automatic port binding will be used (if dockerfile exposes ports)
+instances=1
 if athena.argument.argument_exists "--instances"; then
 	athena.argument.get_argument_and_remove "--instances" "instances"
 	docker_options=("-P")
-	instance_name="multiple-0"
+fi
+
+if [[ "$type" != "hub" ]]; then
+	if ! athena.argument.argument_exists_and_remove "--skip-hub"; then
+		container_name=
+		if athena.argument.argument_exists "--link-hub"; then
+			athena.argument.get_argument_and_remove "--link-hub" "container_name"
+		else
+			container_name="$(athena.plugins.selenium.get_container_name hub)"
+		fi
+
+		if ! athena.docker.is_container_running "$container_name"; then
+			athena.debug "Skipped auto link with Selenium Hub '${container_name}'. Container is not running."
+		else
+			athena.info "Auto linking with Selenium Hub '${container_name}'..."
+			docker_options+=("--link" "${container_name}:hub")
+		fi
+	fi
+
+	if ! athena.argument.argument_exists_and_remove "--skip-proxy"; then
+		container_name=
+		if athena.argument.argument_exists "--link-proxy"; then
+			athena.argument.get_argument_and_remove "--link-proxy" "container_name"
+		else
+			athena.plugin.require "proxy"
+			container_name="$(athena.plugins.proxy.get_container_name)"
+		fi
+
+		if ! athena.docker.is_container_running "$container_name"; then
+			athena.debug "Skipped auto link with Proxy '${container_name}'. Container is not running."
+		else
+			athena.info "Auto linking with Proxy '${container_name}'..."
+			docker_options+=("--link" "${container_name}:athena-proxy")
+		fi
+	fi
 fi
 
 # add other docker options
 athena.argument.get_arguments "args"
 docker_options+=("${args[@]}")
-image_name=$(athena.plugins.selenium.get_image_name $type)
 for ((i=1; i<=$instances; i++));
 do
 	case $type in
 		"hub")
-			athena.plugins.selenium.start_hub "$image_name:$version" "$instance_name" "${docker_options[@]}"
+			athena.plugins.selenium.start_hub "$version" "$instance_id" "${docker_options[@]}"
 			;;
 		"firefox"|"firefox-debug"|"chrome"|"chrome-debug")
-			athena.plugins.selenium.start_selenium_browser "$type" "$image_name:$version" "$instance_name" "${docker_options[@]}"
+			athena.plugins.selenium.start_selenium_browser "$type" "$version" "$instance_id" "${docker_options[@]}"
 			;;
 		"phantomjs")
-			athena.plugins.selenium.start_phantomjs_browser "$image_name:$version" "$instance_name" "${docker_options[@]}"
+			athena.plugins.selenium.start_phantomjs_browser "$version" "$instance_id" "${docker_options[@]}"
 			;;
 		*)
-			athena.fatal "type '$type' not supported!"
+			athena.fatal "Grid component '$type' not supported..."
 			;;
 	esac
-	instance_name="multiple-$i"
+	instance_id=$i
 done

--- a/bin/cmd/start_pre.sh
+++ b/bin/cmd/start_pre.sh
@@ -38,38 +38,8 @@ if athena.argument.argument_exists "--instances"; then
 fi
 
 if [[ "$type" != "hub" ]]; then
-	if ! athena.argument.argument_exists_and_remove "--skip-hub"; then
-		container_name=
-		if athena.argument.argument_exists "--link-hub"; then
-			athena.argument.get_argument_and_remove "--link-hub" "container_name"
-		else
-			container_name="$(athena.plugins.selenium.get_container_name hub)"
-		fi
-
-		if ! athena.docker.is_container_running "$container_name"; then
-			athena.debug "Skipped auto link with Selenium Hub '${container_name}'. Container is not running."
-		else
-			athena.info "Auto linking with Selenium Hub '${container_name}'..."
-			docker_options+=("--link" "${container_name}:hub")
-		fi
-	fi
-
-	if ! athena.argument.argument_exists_and_remove "--skip-proxy"; then
-		container_name=
-		if athena.argument.argument_exists "--link-proxy"; then
-			athena.argument.get_argument_and_remove "--link-proxy" "container_name"
-		else
-			athena.plugin.require "proxy"
-			container_name="$(athena.plugins.proxy.get_container_name)"
-		fi
-
-		if ! athena.docker.is_container_running "$container_name"; then
-			athena.debug "Skipped auto link with Proxy '${container_name}'. Container is not running."
-		else
-			athena.info "Auto linking with Proxy '${container_name}'..."
-			docker_options+=("--link" "${container_name}:athena-proxy")
-		fi
-	fi
+	athena.plugins.selenium.add_link_to_docker_options "hub" "hub"
+	athena.plugins.selenium.add_link_to_docker_options "proxy" "athena-proxy"
 fi
 
 # add other docker options

--- a/bin/cmd/stop_pre.sh
+++ b/bin/cmd/stop_pre.sh
@@ -16,43 +16,30 @@ EOF
 
 type=$(athena.arg 1)
 athena.argument.pop_arguments 1
-port=""
-instance_nr=""
 
+instance_id=
 if athena.argument.argument_exists "--port"; then
-	athena.argument.get_argument_and_remove "--port" "port"
+	athena.argument.get_argument_and_remove "--port" "instance_id"
+elif athena.argument.argument_exists "--instance"; then
+	athena.argument.get_argument_and_remove "--instance" "instance_id"
 fi
 
-if athena.argument.argument_exists "--instance"; then
-	athena.argument.get_argument_and_remove "--instance" instance_nr
-fi
-
-if [ -n "$port" -a -n "$instance_nr" ]; then
-	athena.fatal "you cannot select --port and --instance at the same time!"
+if [[ -n "$instance_id" ]]; then
+	athena.info "Criteria: port or instance id of ${instance_id} set..."
 fi
 
 case "$type" in
 	"all")
-		athena.plugins.selenium.stop_all_hubs
-		athena.plugins.selenium.stop_all_browsers
+		athena.info "Stopping all components..."
+		athena.plugins.selenium.stop_components
 	;;
 	"hub")
-		if [ -n "$port" ]; then
-			athena.plugins.selenium.stop_hub "$port"
-		elif [ -n "$instance_nr" ]; then
-			athena.plugins.selenium.stop_hub "multiple-$instance_nr"
-		else
-			athena.plugins.selenium.stop_all_hubs
-		fi
+		athena.info "Stopping hub..."
+		athena.plugins.selenium.stop_components "hub" $instance_id
 	;;
 	"firefox"|"firefox-debug"|"chrome"|"chrome-debug"|"phantomjs")
-		if [ -n "$port" ]; then
-			athena.plugins.selenium.stop_browser "$type" "$port"
-		elif [ -n "$instance_nr" ]; then
-			athena.plugins.selenium.stop_browser "$type" "multiple-$instance_nr"
-		else
-			athena.plugins.selenium.stop_all_browsers "$type"
-		fi
+		athena.info "Stopping ${type}..."
+		athena.plugins.selenium.stop_components "$type" $instance_id
 	;;
 	*)
 		athena.fatal "Unrecognized component ${type}."

--- a/bin/cmd/terminal_pre.sh
+++ b/bin/cmd/terminal_pre.sh
@@ -1,7 +1,7 @@
 CMD_DESCRIPTION="Starts a shell inside the component."
 
-athena.usage 1 "<type|component_name> [--port=<port>|--instance=<instance_nr>]" "$(cat <<EOF
-    <type|component_name>      ; Starts shell in the specific <type> (hub, firefox, ...) or
+athena.usage 1 "<type> [--port=<port>|--instance=<instance_nr>]" "$(cat <<EOF
+    <type>                     ; Starts shell in the specific <type> (hub, firefox, ...) or
                                ; in the <component_name> like seen in 'athena info' output
     [--port=<port>]            ; In case the <type> to access was not started without a port
                                ; the <port> needs to be specified
@@ -15,38 +15,17 @@ EOF
 )"
 
 type="$(athena.arg 1)"
-port=""
-instance_nr=""
-
+instance_id=
 if athena.argument.argument_exists "--port"; then
-	athena.argument.get_argument_and_remove "--port" "port"
+	athena.argument.get_argument_and_remove "--port" "instance_id"
+elif athena.argument.argument_exists "--instance"; then
+	athena.argument.get_argument_and_remove "--instance" "instance_id"
 fi
 
-if athena.argument.argument_exists "--instance"; then
-	athena.argument.get_argument_and_remove "--instance" instance_nr
+if ! athena.docker.is_container_running "$container_name"; then
+	athena.os.exit_with_msg "Container '$container_name' isn't running.."
 fi
 
-if [ -n "$port" -a -n "$instance_nr" ]; then
-	athena.fatal "you cannot select --port and --instance at the same time!"
-fi
-
-port=${port:-default}
-
-# athena.arg(1) == component name
-if athena.docker.is_container_running "$type"; then
-	container_name=$type
-else
-	if [ -n "$instance_nr" ]; then
-		container_name="$(athena.plugins.selenium._type_prefix $type)-multiple-$instance_nr-$(athena.os.get_instance)"
-	else
-		container_name="$(athena.plugins.selenium._type_prefix $type)-$port-$(athena.os.get_instance)"
-	fi
-
-	if ! athena.docker.is_container_running "$container_name"; then
-		athena.os.exit_with_msg "container '$container_name' isn't running"
-	fi
-fi
-
-
-athena.info "placing you into the container '$container_name'"
+container_name=$(athena.plugins.selenium.get_container_name "$type" $instance_id)
+athena.info "Placing you into the container '$container_name'..."
 athena.docker.exec -ti "$container_name" /usr/bin/env bash

--- a/bin/lib/functions.sh
+++ b/bin/lib/functions.sh
@@ -128,11 +128,13 @@ function athena.plugins.selenium.remove_images_of_type()
 # USAGE: athena.plugins.selenium.add_link_to_docker_options <type> <link_name>
 function athena.plugins.selenium.add_link_to_docker_options()
 {
+	athena.argument.argument_is_not_empty_or_fail "$1" "type"
+	athena.argument.argument_is_not_empty_or_fail "$2" "link_name"
 	local type="$1"
 	local link_name="$2"
 
 	if athena.argument.argument_exists_and_remove "--skip-${type}"; then
-		athena.info "Skipping auto link with ${type}..."
+		athena.color.print_info "Skipping auto link with ${type}..."
 		return 1
 	fi
 
@@ -152,11 +154,11 @@ function athena.plugins.selenium.add_link_to_docker_options()
 		fi
 
 		if ! athena.docker.is_container_running "$container_name"; then
-			athena.debug "Skipped auto link with ${type} '${container_name}'. Container is not running."
+			athena.color.print_debug "Skipped auto link with ${type} '${container_name}'. Container is not running."
 			return 1
 		fi
 	fi
 
-	athena.info "Auto linking with $type container '${container_name}'..."
+	athena.color.print_info "Auto linking with $type container '${container_name}'..."
 	docker_options+=("--link" "${container_name}:${link_name}")
 }

--- a/bin/lib/functions.sh
+++ b/bin/lib/functions.sh
@@ -1,168 +1,23 @@
-# This function starts the component with the given image name and instance.
-# USAGE: athena.plugins.selenium.start_component <name_prefix> <docker_image> <instance_id> <string_in_logs> [<docker_option>...]
-# RETURN: 0 (true), 1 (false)
-function athena.plugins.selenium.start_component()
+# Get container name for given component
+# USAGE: athena.plugins.selenium.get_container_name [<type>] [<instance_id>]
+function athena.plugins.selenium.get_container_name()
 {
-	athena.argument.argument_is_not_empty_or_fail "$1" "name prefix"
-	athena.argument.argument_is_not_empty_or_fail "$2" "docker image"
-	athena.argument.argument_is_not_empty_or_fail "$3" "instance id"
-	athena.argument.argument_is_not_empty_or_fail "$4" "string in logs"
-	local name_prefix=$1
-	local docker_image="$2"
-	local instance_id="$3"
-	local string_in_logs="$4"
-
-	local container_name="${name_prefix}-${instance_id}-$(athena.os.get_instance)"
-	local -a docker_options=("-d" "--name" "$container_name" "${@:5}")
-
-	if athena.docker.is_container_running "$container_name"; then
-		athena.os.exit_with_msg "container '$container_name' already started"
+	local container_name
+	container_name="$(athena.os.get_prefix)-selenium-$(athena.os.get_instance)"
+	if [[ -n "$1" ]]; then
+		container_name="$container_name-${1}"
 	fi
-
-	athena.color.print_info "starting '$container_name'"
-
-	athena.docker.run "${docker_options[@]}" "$docker_image" 1>/dev/null
-	if [ $? -ne 0 ]; then
-		athena.os.exit_with_msg "problem starting container '$container_name'!"
+	if [[ -n "$2" ]]; then
+		container_name="$container_name-${2}"
 	fi
-	athena.docker.wait_for_string_in_container_logs "$container_name" "$string_in_logs"
+	echo "$container_name"
 }
-
-# USAGE: athena.plugins.selenium._type_prefix <type>
-function athena.plugins.selenium._type_prefix()
-{
-	case $1 in
-		"hub")
-			echo athena-selenium-hub
-			;;
-		"firefox"|"firefox-debug"|"chrome"|"chrome-debug"|"phantomjs")
-			echo athena-selenium-node-$1
-			;;
-		*)
-			athena.os.exit_with_msg "type '$1' not supported!"
-			;;
-	esac
-}
-
-# Start a Selenium Hub with given docker image and instance ID.
-# USAGE: athena.plugins.selenium.start_hub <docker_image> <instance_id>
-function athena.plugins.selenium.start_hub()
-{
-	local name_prefix="$(athena.plugins.selenium._type_prefix hub)"
-	local docker_image=$1
-	local instance_id=$2
-	local string_in_logs="Selenium Grid hub is up and running"
-
-	athena.plugins.selenium.start_component \
-		"$name_prefix" \
-		"$docker_image" \
-		"$instance_id" \
-		"$string_in_logs" \
-		"${@:3}"
-}
-
-# Start a browser with given options. This function will wait for the
-# container logs, to have the given <string_in_logs>.
-# USAGE: athena.plugins.selenium.start_browser <type> <docker_image> <instance_id> <string_in_logs>
-function athena.plugins.selenium.start_browser()
-{
-	local name_prefix="$(athena.plugins.selenium._type_prefix $1)"
-	local docker_image=$2
-	local instance_id=$3
-	local string_in_logs="$4"
-
-	athena.plugins.selenium.start_component \
-		"$name_prefix" \
-		"$docker_image" \
-		"$instance_id" \
-		"$string_in_logs" \
-		"${@:5}"
-}
-
-# Start a Selenium browser of a given type., such as firefox, firefox-debug, etc.
-# USAGE: athena.plugins.selenium.start_selenium_browser <type> <docker_image> <instance_id>
-function athena.plugins.selenium.start_selenium_browser()
-{
-	local string_in_logs="The node is registered to the hub and ready to use"
-	athena.plugins.selenium.start_browser "$1" "$2" "$3" "$string_in_logs" "${@:4}"
-}
-
-# Start a PhantomJS Browser with given image and instance ID.
-# USAGE: athena.plugins.selenium.start_phantomjs_browser <docker_image> <instance_id>
-function athena.plugins.selenium.start_phantomjs_browser()
-{
-	local string_in_logs="Registered with grid hub"
-	athena.plugins.selenium.start_browser "phantomjs" "$1" "$2" "$string_in_logs" "${@:3}"
-}
-
-
-
-# Stop a component with a given container name and instance ID.
-# E.g. athena.plugins.selenium.stop_component athena-selenium 1
-# This would would stop the first running container with name athena-selenium.
-# USAGE: athena.plugins.selenium.stop_component <container_name> <instance_id>
-function athena.plugins.selenium.stop_component()
-{
-	athena.argument.argument_is_not_empty_or_fail "$1" "container name"
-	athena.argument.argument_is_not_empty_or_fail "$2" "instance id"
-	athena.docker.stop_container "${1}-${2}-$(athena.os.get_instance)"
-}
-
-# Stop a running selenium hub with given instance ID.
-# E.g. athena.plugins.selenium.stop_hub 1
-# This would stop the first instance of a running selenium hub.
-# USAGE: athena.plugins.selenium.stop_hub <instance_id>
-function athena.plugins.selenium.stop_hub()
-{
-	local name_prefix="athena-selenium-hub"
-	local instance_id="$1"
-	athena.color.print_info "Stopping hub with port or instance id of '$instance_id'.."
-	athena.plugins.selenium.stop_component "$name_prefix" "$instance_id"
-}
-
-# Stop a running browser of type and given instance ID.
-# E.g. athena.plugins.selenium.stop_browser firefox 1
-# This would stop the first running instance of a firefox browser.
-# USAGE: athena.plugins.selenium.stop_browser <type> <instance_id>
-function athena.plugins.selenium.stop_browser()
-{
-	local name_prefix="athena-selenium-node-${1}"
-	local instance_id="$2"
-	athena.color.print_info "Stopping $1 browser with port or instance id of '$instance_id'.."
-	athena.plugins.selenium.stop_component "$name_prefix" "$instance_id"
-}
-
-# Stop all running selenium hubs.
-# USAGE: athena.plugins.selenium.stop_all_hubs
-function athena.plugins.selenium.stop_all_hubs()
-{
-	athena.color.print_info "Stopping all hubs..."
-	athena.docker.stop_all_containers "athena-selenium-hub"
-}
-
-# Stop all running browsers. You can optionally define a browser type.
-# E.g. athena.plugins.selenium.stop_all_browsers firefox
-# USAGE: athena.plugins.selenium.stop_all_browsers [<type>]
-function athena.plugins.selenium.stop_all_browsers()
-{
-	if [[ -z "$1" ]]; then
-		athena.color.print_info "Stopping all browsers..."
-		athena.docker.stop_all_containers "athena-selenium-node"
-		return 0
-	fi
-
-	athena.color.print_info "Stopping all $1 browsers..."
-	athena.docker.stop_all_containers "athena-selenium-node-$1"
-}
-
 
 # Get the image name for given type
-# e.g. athena.plugins.selenium.get_image_name firefox
 # USAGE: athena.plugins.selenium.get_image_name <type>
 function athena.plugins.selenium.get_image_name()
 {
 	local type=$1
-
 	case "$type" in
 		"hub")
 			echo "selenium/hub"
@@ -174,15 +29,90 @@ function athena.plugins.selenium.get_image_name()
 			echo "akeem/selenium-node-phantomjs"
 		;;
 		*)
-			athena.os.exit_with_msg "Unrecognized component ${type}."
+			athena.os.exit_with_msg "Grid component '${type}' not supported...."
 		;;
 	esac
+}
+
+
+# This function starts the component with the given image name and instance.
+# USAGE: athena.plugins.selenium.start_component <container_name> <image_name> <string_in_logs> [<docker_option>...]
+# RETURN: 0 (true), 1 (false)
+function athena.plugins.selenium.start_component()
+{
+	athena.argument.argument_is_not_empty_or_fail "$1" "container name"
+	athena.argument.argument_is_not_empty_or_fail "$2" "image name"
+	athena.argument.argument_is_not_empty_or_fail "$3" "string in logs"
+	local container_name="$1"
+	local image_name="$2"
+	local string_in_logs="$3"
+	local docker_options=("-d" "--name" "$container_name" "${@:4}")
+
+	if athena.docker.is_container_running "$container_name"; then
+		athena.os.exit_with_msg "Container '$container_name' already started..."
+	elif ! athena.docker.run "${docker_options[@]}" "$image_name" 1>/dev/null; then
+		athena.os.exit_with_msg "Problem starting container '$container_name'..."
+	fi
+	athena.color.print_info "Starting '$container_name'..."
+	athena.docker.wait_for_string_in_container_logs "$container_name" "$string_in_logs"
+}
+
+# Start a Selenium Hub of <version>.
+# USAGE: athena.plugins.selenium.start_hub <version> <instance_id> [<docker_options>...]
+function athena.plugins.selenium.start_hub()
+{
+	local container_name="$(athena.plugins.selenium.get_container_name hub $2)"
+	local image_name="$(athena.plugins.selenium.get_image_name hub):${1}"
+	local string_in_logs="Selenium Grid hub is up and running"
+	local docker_options=("${@:3}")
+
+	athena.plugins.selenium.start_component "$container_name" "$image_name" "$string_in_logs" "${docker_options[@]}"
+}
+
+# Start a browser with given options. This function will wait for the
+# container logs, to have the given <string_in_logs>.
+# USAGE: athena.plugins.selenium.start_browser <type> <version> <instance_id> <string_in_logs> [<docker_options>...]
+function athena.plugins.selenium.start_browser()
+{
+	local container_name="$(athena.plugins.selenium.get_container_name $1 $3)"
+	local image_name="$(athena.plugins.selenium.get_image_name $1):${2}"
+	local string_in_logs="$4"
+	local docker_options=("${@:5}")
+
+	athena.plugins.selenium.start_component "$container_name" "$image_name" "$string_in_logs" "${docker_options[@]}"
+}
+
+# Start a Selenium browser of a given type., such as firefox, firefox-debug, etc.
+# USAGE: athena.plugins.selenium.start_selenium_browser <type> <version> <instance_id> [<docker_options>...]
+function athena.plugins.selenium.start_selenium_browser()
+{
+	local docker_options=("${@:4}")
+	local string_in_logs="The node is registered to the hub and ready to use"
+	athena.plugins.selenium.start_browser "$1" "$2" "$3" "$string_in_logs" "${docker_options[@]}"
+}
+
+# Start a PhantomJS Browser with given image and instance ID.
+# USAGE: athena.plugins.selenium.start_phantomjs_browser <version> <instance_id> [<docker_options>...]
+function athena.plugins.selenium.start_phantomjs_browser()
+{
+	local string_in_logs="Registered with grid hub"
+	local docker_options=("${@:3}")
+	athena.plugins.selenium.start_browser "phantomjs" "$1" "$2" "$string_in_logs" "${docker_options[@]}"
+}
+
+# Stop a running selenium hub with given instance ID.
+# This would stop the first instance of a running selenium hub.
+# USAGE: athena.plugins.selenium.stop_components [<type>] [<instance_id>]
+function athena.plugins.selenium.stop_components()
+{
+	athena.docker.stop_all_containers "$(athena.plugins.selenium.get_container_name $1 $2)" --global
 }
 
 # Remove all docker images of the specified type
 # USAGE: athena.plugins.selenium.remove_images_of_type <type>
 function athena.plugins.selenium.remove_images_of_type()
 {
+	athena.argument.argument_is_not_empty_or_fail "$1" "type"
 	local answer
 	local image_name=$(athena.plugins.selenium.get_image_name $1)
 

--- a/docs/getting-started/running-grid-hub-and-nodes.md
+++ b/docs/getting-started/running-grid-hub-and-nodes.md
@@ -19,30 +19,11 @@ Nodes available:
 
 # Link Grid Nodes to Local Hub
 
-If you started a Selenium Hub locally, and you want your node to be able to register in it, you'll have to link both containers.
+When a Selenium Grid Node is started, it will try to automatically link with a running Grid Hub or/and Proxy Server.
 
-`athena info` command will list all the runnig containers.
+In case `--skip-hub` or/and `--skip-proxy` exists, the link will not be performed.
 
-```bash
-$ athena info
-       ___   __  __
-      /   | / /_/ /_  ___  ____  ____ _
-     / /| |/ __/ __ \/ _ \/ __ \/ __  /
-    / ___ / /_/ / / /  __/ / / / /_/ /
-   /_/  |_\__/_/ /_/\___/_/ /_/\__,_/
-                              v0.4.0
-  ==================================
-
-[INFO] Running containers [image|container|status]:
-
- * selenium/hub  athena-selenium-hub-default-0  [UP]
-```
-
-Now we use the container name:
-
-```bash
-$ athena selenium start firefox 2.53.0 --link=athena-selenium-hub-default-0:hub
-```
+For performing a link with another running container, you can optionally specify `--link-hub=<container_name>` and/or `--link-proxy=<container_name>`.
 
 # Expose Grid Hub or Nodes Port
 

--- a/tests/test.functions.sh
+++ b/tests/test.functions.sh
@@ -1,165 +1,19 @@
 athena.plugin.require "selenium"
 
-function testcase_athena.plugins.selenium.start_component()
+function testcase_athena.plugins.selenium.get_container_name()
 {
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component"
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "name prefix"
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "name prefix" "docker image"
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "name prefix" "docker image" "instance id"
+	athena.test.mock.outputs "athena.os.get_prefix" "myprefix"
+	athena.test.mock.outputs "athena.os.get_instance" "1"
 
-	athena.test.mock.returns "athena.docker.is_container_running" 0
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "name prefix" "docker image" "instance id"
-
-	local name_prefix="my-container"
-	local instance_id="1"
-	local docker_image="myimage:latest"
-	local string_in_logs="some string"
-	local os_instance_id="1"
-	local container_name="${name_prefix}-${instance_id}-${os_instance_id}"
-
-	athena.test.mock.outputs "athena.os.get_instance" "$os_instance_id"
-	athena.test.mock "athena.docker.is_container_running" "_echo_args"
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "$name_prefix" "$docker_image" "$instance_id" "$string_in_logs"
-
-	athena.test.mock.returns "athena.docker.is_container_running" 1
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.mock.returns "athena.docker.run" 1
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "$name_prefix" "$docker_image" "$instance_id" "$string_in_logs"
-
-	local actual_output
-	athena.test.mock "athena.docker.run" "_echo_to_var"
-	athena.test.mock "athena.docker.wait_for_string_in_container_logs" "_echo_to_var"
-	athena.plugins.selenium.start_component "$name_prefix" "$docker_image" "$instance_id" "$string_in_logs"
-
-	local expected_output=$(cat -- <<EOF
-
--d --name $container_name $docker_image
-$container_name $string_in_logs
-EOF
-)
-	athena.test.assert_value "$actual_output" "$expected_output" "$name_prefix"
-
-	actual_output=""
-	athena.plugins.selenium.start_component "$name_prefix" "$docker_image" "$instance_id" "$string_in_logs" "--opt1" "--opt2"
-
-	local expected_output=$(cat -- <<EOF
-
--d --name $container_name --opt1 --opt2 $docker_image
-$container_name $string_in_logs
-EOF
-)
-	athena.test.assert_value "$actual_output" "$expected_output" "$name_prefix"
-}
-
-function testcase_athena.plugins.selenium.start_hub()
-{
-	local name_prefix="myprefix"
-	local docker_image="myimage:1.2.3"
-	local instance_id="1"
-	local string_in_logs="Selenium Grid hub is up and running"
-
-	athena.test.mock.outputs "athena.plugins.selenium._type_prefix" "$name_prefix"
-	athena.test.mock "athena.plugins.selenium.start_component" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.start_hub" "$name_prefix $docker_image $instance_id $string_in_logs" "$docker_image" "$instance_id"
-
-	athena.test.assert_output "athena.plugins.selenium.start_hub" "$name_prefix $docker_image $instance_id $string_in_logs --opt1 --opt2" "$docker_image" "$instance_id" "--opt1" "--opt2"
-}
-
-function testcase_athena.plugins.selenium.start_browser()
-{
-	local name_prefix="myprefix"
-	local docker_image="myimage:1.2.3"
-	local instance_id="myinstance"
-	local string_in_logs="Browser is registered"
-
-	athena.test.mock.outputs "athena.plugins.selenium._type_prefix" "$name_prefix"
-	athena.test.mock "athena.plugins.selenium.start_component" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.start_browser" "$name_prefix $docker_image $instance_id $string_in_logs" "browser" "$docker_image" "$instance_id" "$string_in_logs"
-
-	athena.test.assert_output "athena.plugins.selenium.start_browser" "$name_prefix $docker_image $instance_id $string_in_logs --opt1 --opt2" "browser" "$docker_image" "$instance_id" "$string_in_logs" "--opt1" "--opt2"
-}
-
-function testcase_athena.plugins.selenium.start_selenium_browser()
-{
-	local type="firefox"
-	local docker_image="selenium/sinpians:1.23"
-	local instance_id="1"
-	local string_in_logs="The node is registered to the hub and ready to use"
-	athena.test.mock "athena.plugins.selenium.start_browser" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.start_selenium_browser" "$type $docker_image $instance_id $string_in_logs" "$type" "$docker_image" "$instance_id"
-}
-
-function testcase_athena.plugins.selenium.start_phantomjs_browser()
-{
-	local type="phantomjs"
-	local docker_image="selenium/sinpians:1.23"
-	local instance_id="1"
-	local string_in_logs="Registered with grid hub"
-	athena.test.mock "athena.plugins.selenium.start_browser" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.start_phantomjs_browser" "$type $docker_image $instance_id $string_in_logs" "$docker_image" "$instance_id"
-}
-
-function testcase_athena.plugins.selenium._type_prefix()
-{
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-hub" "hub"
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-node-firefox" "firefox"
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-node-firefox-debug" "firefox-debug"
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-node-chrome" "chrome"
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-node-chrome-debug" "chrome-debug"
-	athena.test.assert_output "athena.plugins.selenium._type_prefix" "athena-selenium-node-phantomjs" "phantomjs"
-
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium._type_prefix" "i-dont-exist"
-}
-
-function testcase_athena.plugins.selenium.stop_component()
-{
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.stop_component"
-	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.stop_component" "mycontainer"
-
-	local container_name="mycontainer"
-	local instance_id="1"
-	local os_instance_id="1"
-	athena.test.mock "athena.docker.stop_container" "_echo_args"
-	athena.test.mock.outputs "athena.os.get_instance" "$os_instance_id"
-	athena.test.assert_output "athena.plugins.selenium.stop_component" "${container_name}-${instance_id}-${os_instance_id}" "$container_name" "$instance_id"
-}
-
-function testcase_athena.plugins.selenium.stop_hub()
-{
-	local instance_id="myid"
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.mock "athena.plugins.selenium.stop_component" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.stop_hub" "athena-selenium-hub $instance_id" "$instance_id"
-}
-
-function testcase_athena.plugins.selenium.stop_browser()
-{
-	local type="phantomjs"
-	local instance_id="myid"
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.mock "athena.plugins.selenium.stop_component" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.stop_browser" "athena-selenium-node-${type} ${instance_id}" "$type" "$instance_id"
-}
-
-function testcase_athena.plugins.selenium.stop_all_hubs()
-{
-	athena.test.mock "athena.docker.stop_all_containers" "_echo_args"
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.assert_output "athena.plugins.selenium.stop_all_hubs" "athena-selenium-hub"
-}
-
-function testcase_athena.plugins.selenium.stop_all_browsers()
-{
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.mock "athena.docker.stop_all_containers" "_echo_args"
-	athena.test.assert_output "athena.plugins.selenium.stop_all_browsers" "athena-selenium-node"
-
-	local type="myphantom"
-	athena.test.assert_output "athena.plugins.selenium.stop_all_browsers" "athena-selenium-node-$type" "$type"
+	athena.test.assert_output "athena.plugins.selenium.get_container_name" "myprefix-selenium-1"
+	athena.test.assert_output "athena.plugins.selenium.get_container_name" "myprefix-selenium-1-mycontainer" "mycontainer"
+	athena.test.assert_output "athena.plugins.selenium.get_container_name" "myprefix-selenium-1-mycontainer-myid" "mycontainer" "myid"
 }
 
 function testcase_athena.plugins.selenium.get_image_name()
 {
+	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.get_image_name"
+
 	athena.test.assert_output "athena.plugins.selenium.get_image_name" "selenium/hub" "hub"
 	athena.test.assert_output "athena.plugins.selenium.get_image_name" "selenium/node-firefox" "firefox"
 	athena.test.assert_output "athena.plugins.selenium.get_image_name" "selenium/node-firefox-debug" "firefox-debug"
@@ -170,26 +24,108 @@ function testcase_athena.plugins.selenium.get_image_name()
 	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.get_image_name" "something"
 }
 
-function testcase_athena.plugins.selenium.remove_images_of_type()
+function testcase_athena.plugins.selenium.start_component()
 {
-	local type="mytype"
-	local docker_image="some/image"
-	athena.test.mock.outputs "athena.plugins.selenium.get_image_name" "$docker_image"
-	athena.test.mock.outputs "athena.docker.images" "${docker_image}:1.23 ${docker_image}:5.01"
-	athena.test.mock "athena.color.print_info" "_void"
-	athena.test.mock "athena.docker.rmi" "_echo_args"
+	local container_name="mycontainer"
+	local image_name="myimage:1.3.4"
+	local string_in_logs="some string"
 
-	local actual_output="$(echo y | athena.plugins.selenium.remove_images_of_type)"
-	local expected_output=$(cat <<EOF
--f $docker_image:1.23
--f $docker_image:5.01
+	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component"
+	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "$container_name" "$image_name"
+
+	athena.test.mock.returns "athena.docker.is_container_running" 0
+	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "$container_name" "$image_name" "$string_in_logs"
+
+	athena.test.mock.returns "athena.docker.is_container_running" 1
+	athena.test.mock.returns "athena.docker.run" 1
+	athena.test.assert_exit_code.expects_fail "athena.plugins.selenium.start_component" "$container_name" "$image_name" "$string_in_logs"
+
+	athena.test.mock "athena.docker.run" "_echo_args"
+	athena.test.mock "athena.color.print_info" "_void"
+	athena.test.mock "athena.docker.run" "_echo_to_var"
+	athena.test.mock "athena.docker.wait_for_string_in_container_logs" "_echo_to_var"
+	local expected_output="$(cat <<EOF
+
+-d --name $container_name $image_name
+$container_name $string_in_logs
 EOF
-)
+)"
+	local actual_output=
+	athena.plugins.selenium.start_component "$container_name" "$image_name" "$string_in_logs"
 	athena.test.assert_value "$actual_output" "$expected_output"
 
-	athena.test.mock.outputs "athena.docker.images" "${docker_image}:1.23"
-	local actual_output="$(echo n | athena.plugins.selenium.remove_images_of_type)"
-	athena.test.assert_value "$actual_output" ""
+	local expected_output="$(cat <<EOF
+
+-d --name $container_name -v /opt/myapp $image_name
+$container_name $string_in_logs
+EOF
+)"
+	local actual_output=
+	athena.plugins.selenium.start_component "$container_name" "$image_name" "$string_in_logs" -v /opt/myapp
+	athena.test.assert_value "$actual_output" "$expected_output"
+}
+
+function testcase_athena.plugins.selenium.start_hub()
+{
+	athena.test.mock "athena.plugins.selenium.get_image_name" "_echo_args"
+	athena.test.mock "athena.plugins.selenium.get_container_name" "_echo_args"
+	athena.test.mock "athena.plugins.selenium.start_component" "_echo_args"
+
+	local version="1.2.3"
+	local instance_id="34"
+	local expected_output="hub ${instance_id} hub:${version} Selenium Grid hub is up and running"
+	athena.test.assert_output "athena.plugins.selenium.start_hub" "${expected_output}" "$version" "$instance_id"
+	athena.test.assert_output "athena.plugins.selenium.start_hub" "${expected_output} -v /opt/myapp" "$version" "$instance_id" -v /opt/myapp
+}
+
+function testcase_athena.plugins.selenium.start_browser()
+{
+	athena.test.mock "athena.plugins.selenium.get_container_name" "_echo_args"
+	athena.test.mock "athena.plugins.selenium.get_image_name" "_echo_args"
+	athena.test.mock "athena.plugins.selenium.start_component" "_echo_args"
+
+	local type="mytype"
+	local version="1.2.3"
+	local instance_id="134"
+	local string_in_logs="my string in the logs"
+	local expected_output="$type $instance_id ${type}:${version} $string_in_logs"
+	athena.test.assert_output "athena.plugins.selenium.start_browser" "${expected_output}" "$type" "$version" "$instance_id" "$string_in_logs"
+	athena.test.assert_output "athena.plugins.selenium.start_browser" "${expected_output} --link something:spinpans" "$type" "$version" "$instance_id" "$string_in_logs" --link something:spinpans
+}
+
+function testcase_athena.plugins.selenium.start_selenium_browser()
+{
+	athena.test.mock "athena.plugins.selenium.start_browser" "_echo_args"
+
+	local type="mytype"
+	local version="1.4.5"
+	local instance_id="533"
+	local expected_output="$type $version $instance_id The node is registered to the hub and ready to use"
+
+	athena.test.assert_output "athena.plugins.selenium.start_selenium_browser" "$expected_output" "$type" "$version" "$instance_id"
+	athena.test.assert_output "athena.plugins.selenium.start_selenium_browser" "$expected_output --someoption" "$type" "$version" "$instance_id" --someoption
+}
+
+function testcase_athena.plugins.selenium.start_phantomjs_browser()
+{
+	athena.test.mock "athena.plugins.selenium.start_browser" "_echo_args"
+
+	local version="1.4.5"
+	local instance_id="533"
+	local expected_output="phantomjs $version $instance_id Registered with grid hub"
+
+	athena.test.assert_output "athena.plugins.selenium.start_phantomjs_browser" "$expected_output" "$version" "$instance_id"
+	athena.test.assert_output "athena.plugins.selenium.start_phantomjs_browser" "$expected_output --someoption" "$version" "$instance_id" --someoption
+}
+
+function testcase_athena.plugins.selenium.stop_components()
+{
+	athena.test.mock "athena.plugins.selenium.get_container_name" "_echo_args"
+	athena.test.mock "athena.docker.stop_all_containers" "_echo_args"
+
+	athena.test.assert_output "athena.plugins.selenium.stop_components" "--global"
+	athena.test.assert_output "athena.plugins.selenium.stop_components" "firefox --global" "firefox"
+	athena.test.assert_output "athena.plugins.selenium.stop_components" "firefox 1 --global" "firefox" "1"
 }
 
 function _void()
@@ -200,7 +136,6 @@ function _void()
 function _echo_args()
 {
 	echo $@
-	return 0
 }
 
 function _echo_to_var()


### PR DESCRIPTION
When a Selenium Grid Node is started, it will try to automatically link
with a running Grid Hub or/and Proxy Server.

In case `--skip-hub` or/and `--skip-proxy` exists, the link will not be performed.

For performing a link with another running container, you can optionally
specify `--link-hub=<container_name>` and/or `--link-proxy=<container_name>`.

**NOTE:** Adding `athena.plugins.selenium.get_container_name` function, also allowed for a code reduction. Completely covered by `tests/`.
